### PR TITLE
lhsmtool_tsm: fix double free on cleanup

### DIFF
--- a/src/lhsmtool_tsm.c
+++ b/src/lhsmtool_tsm.c
@@ -764,6 +764,7 @@ cleanup:
 		}
 	}
 	free(session);
+	session = NULL;
 	tsm_cleanup(DSM_MULTITHREAD);
 
 	return rc;
@@ -814,6 +815,7 @@ cleanup:
 			free(thread[i]);
 	}
 	free(thread);
+	thread = NULL;
 
 	return rc;
 }


### PR DESCRIPTION
```
[ERROR] 1488477084.291319 [11412] tsmapi.c:513 dsmInitEx: handle: 1 ANS1352E (RC52)   The session is rejected. Your password has expired.
[ERROR] 1488477084.291333 [11412] lhsmtool_tsm.c:746 tsm_init failed: Operation canceled (125)
[ERROR] 1488477084.291350 [11412] lhsmtool_tsm.c:847 ct_connect_sessions failed: Operation canceled (125)
```