### PR TITLE
Increased TSM-buffer size to 16 MiB

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ltsm (0.9.2) unstable; urgency=low
+
+  * Increased buffersize to 16 MiB
+
+ -- Samuel Hasert <s.hasert@gsi.de>  Mon, 15 Sep 2025 11:33:05 +0200
+
 ltsm (0.9.1) unstable; urgency=low
 
   * Finalize remove of FSQ project.

--- a/rpm/ltsm.spec
+++ b/rpm/ltsm.spec
@@ -64,6 +64,9 @@ rm -rf %{buildroot}
 
 %changelog
 
+* Mon Sep 15 2025 Samuel Hasert <s.hasert@gsi.de> 0.9.2
+- Increased buffersize to 16 MiB
+
 * Thu Jul 28 2022 Thomas Stibor <t.stibor@gsi.de> 0.9.0-1
 - Remove FSQ to keep LTSM as a Lustre TSM copytool project.
 

--- a/src/lib/common.c
+++ b/src/lib/common.c
@@ -152,12 +152,20 @@ int crc32file(const char *filename, uint32_t *crc32result)
 	FILE *file;
 	size_t cur_read;
 	uint32_t crc32sum = 0;
-	unsigned char buf[TSM_BUF_LENGTH] = {0};
+	unsigned char* buf = malloc(TSM_BUF_LENGTH); // reserve memory on heap because stack too small
+	if (!buf) {
+		rc = errno;
+		CT_ERROR(rc, "malloc");
+
+        return rc;
+	}
 
 	file = fopen(filename, "r");
 	if (file == NULL) {
 		rc = -errno;
 		CT_ERROR(rc, "fopen failed on '%s'", filename);
+		if (buf) free(buf);
+		buf = NULL;
 
 		return rc;
 	}
@@ -174,9 +182,10 @@ int crc32file(const char *filename, uint32_t *crc32result)
 
 	} while (!feof(file));
 
-	int rc_minor;
+	if (buf) free(buf);
+	buf = NULL;
 
-	rc_minor = fclose(file);
+	int rc_minor = fclose(file);
 	if (rc_minor) {
 		rc_minor = -errno;
 		CT_ERROR(rc_minor, "fclose failed on '%s'", filename);
@@ -184,7 +193,9 @@ int crc32file(const char *filename, uint32_t *crc32result)
 		return rc_minor;
 	}
 
-	*crc32result = crc32sum;
+    if (!rc) {
+		*crc32result = crc32sum;
+    }
 
 	return rc;
 }

--- a/src/lib/common.h
+++ b/src/lib/common.h
@@ -46,7 +46,7 @@
 #endif
 
 #ifndef TSM_BUF_LENGTH
-#define TSM_BUF_LENGTH	262144	/* 256 KiB. */
+#define TSM_BUF_LENGTH	16777216 /* 16 MiB */
 #endif
 
 #ifndef MAX_OPTIONS_LENGTH

--- a/src/ltsmc.c
+++ b/src/ltsmc.c
@@ -493,7 +493,11 @@ int main(int argc, char *argv[])
 			goto cleanup_tsm;
 		}
 
-		char buf[TSM_BUF_LENGTH] = {0};
+		char* buf = malloc(TSM_BUF_LENGTH);
+		if (!buf) {
+			goto cleanup_tsm;
+		}
+
 		size_t size;
 		do {
 			size = fread(buf, 1, TSM_BUF_LENGTH, stdin);
@@ -510,6 +514,9 @@ int main(int argc, char *argv[])
 				break;
 			}
 		} while (!feof(stdin));
+
+		if (buf) free(buf);
+		buf = NULL;
 
 		rc = tsm_fclose(&session);
 		if (rc)


### PR DESCRIPTION
The TSM-buffer size was increased to 16 MiB. As a consquence of this the TSM buffer has to be allocated on the heap for ltsmc.c and common.c to prevent segmentation faults.