### PR TITLE
Added the option to set fsname manually

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ltsm (0.9.3) unstable; urgency=low
+
+  * Added option to set fsname manually
+
+ -- Samuel Hasert <s.hasert@gsi.de>  Tue, 06 Jan 2026 10:26:20 +0200
+
 ltsm (0.9.2) unstable; urgency=low
 
   * Increased buffersize to 16 MiB

--- a/rpm/ltsm.spec
+++ b/rpm/ltsm.spec
@@ -64,6 +64,9 @@ rm -rf %{buildroot}
 
 %changelog
 
+* Tue Jan 06 2026 Samuel Hasert <s.hasert@gsi.de> 0.9.3
+- Added option to set fsname manually
+
 * Mon Sep 15 2025 Samuel Hasert <s.hasert@gsi.de> 0.9.2
 - Increased buffersize to 16 MiB
 

--- a/src/lhsmtool_tsm.c
+++ b/src/lhsmtool_tsm.c
@@ -299,7 +299,7 @@ static int ct_parseopts(int argc, char *argv[])
 		{.name = "owner",          .has_arg = required_argument, .flag = NULL,                  .val = 'o'},
 		{.name = "servername",     .has_arg = required_argument, .flag = NULL,                  .val = 's'},
 		{.name = "conf",	   .has_arg = required_argument, .flag = NULL,		        .val = 'c'},
-		{.name = "fsname",	   .has_arg = optional_argument, .flag = NULL,		        .val = 'f'},
+		{.name = "fsname",	   .has_arg = required_argument, .flag = NULL,		        .val = 'f'},
 		{.name = "verbose",        .has_arg = required_argument, .flag = NULL,                  .val = 'v'},
 		{.name = "dry-run",	   .has_arg = no_argument,	 .flag = &opt.o_dry_run,        .val =   1},
 		{.name = "restore-stripe", .has_arg = no_argument,	 .flag = &opt.o_restore_stripe, .val =   1},
@@ -396,8 +396,9 @@ static int ct_parseopts(int argc, char *argv[])
 	opt.o_mnt_fd = -1;
 
 	/* Filespace name is set to Lustre mount point. */
-	if (!opt.o_fsname[0])
+	if (!opt.o_fsname[0]) {
 		strncpy(opt.o_fsname, opt.o_mnt, DSM_MAX_FSNAME_LENGTH);
+	}
 
 	const size_t len_fsname = strlen(opt.o_fsname);
 	if (len_fsname > 2 && opt.o_fsname[len_fsname - 1] == '/')

--- a/src/lhsmtool_tsm.c
+++ b/src/lhsmtool_tsm.c
@@ -132,7 +132,7 @@ static void usage(const char *cmd_name, const int rc)
 		"\t-c, --conf <file>\n"
 		"\t\t""option conf file\n"
 		"\t-f, --fsname\n"
-		"\t\t""set fsname manually\n"
+		"\t\t""set fsname manually </override_fs_name>\n"
 		"\t-v, --verbose {error, warn, message, info, debug}"
 		" [default: %s]\n"
 		"\t\t""produce more verbose output\n"

--- a/src/lhsmtool_tsm.c
+++ b/src/lhsmtool_tsm.c
@@ -131,6 +131,8 @@ static void usage(const char *cmd_name, const int rc)
 		"\t\t""hostname of tsm server\n"
 		"\t-c, --conf <file>\n"
 		"\t\t""option conf file\n"
+		"\t-f, --fsname\n"
+		"\t\t""set fsname manually\n"
 		"\t-v, --verbose {error, warn, message, info, debug}"
 		" [default: %s]\n"
 		"\t\t""produce more verbose output\n"
@@ -297,6 +299,7 @@ static int ct_parseopts(int argc, char *argv[])
 		{.name = "owner",          .has_arg = required_argument, .flag = NULL,                  .val = 'o'},
 		{.name = "servername",     .has_arg = required_argument, .flag = NULL,                  .val = 's'},
 		{.name = "conf",	   .has_arg = required_argument, .flag = NULL,		        .val = 'c'},
+		{.name = "fsname",	   .has_arg = no_argument, .flag = NULL,		        .val = 'f'},
 		{.name = "verbose",        .has_arg = required_argument, .flag = NULL,                  .val = 'v'},
 		{.name = "dry-run",	   .has_arg = no_argument,	 .flag = &opt.o_dry_run,        .val =   1},
 		{.name = "restore-stripe", .has_arg = no_argument,	 .flag = &opt.o_restore_stripe, .val =   1},
@@ -308,7 +311,7 @@ static int ct_parseopts(int argc, char *argv[])
 	int c, rc;
 	optind = 0;
 
-	while ((c = getopt_long(argc, argv, "a:t:n:p:o:s:c:v:h",
+	while ((c = getopt_long(argc, argv, "a:t:n:p:o:s:c:f:v:h",
 				long_opts, NULL)) != -1) {
 		switch (c) {
 		case 'a': {
@@ -343,6 +346,11 @@ static int ct_parseopts(int argc, char *argv[])
 		}
 		case 'c': {
 			read_conf(optarg);
+			break;
+		}
+		case 'f': {
+			strncpy(opt.o_fsname, optarg,
+				DSM_MAX_FSNAME_LENGTH);
 			break;
 		}
 		case 'v': {
@@ -388,7 +396,9 @@ static int ct_parseopts(int argc, char *argv[])
 	opt.o_mnt_fd = -1;
 
 	/* Filespace name is set to Lustre mount point. */
-	strncpy(opt.o_fsname, opt.o_mnt, DSM_MAX_FSNAME_LENGTH);
+	if (!opt.o_fsname[0])
+        strncpy(opt.o_fsname, opt.o_mnt, DSM_MAX_FSNAME_LENGTH);
+
 	const size_t len_fsname = strlen(opt.o_fsname);
 	if (len_fsname > 2 && opt.o_fsname[len_fsname - 1] == '/')
 		opt.o_fsname[len_fsname - 1] = '\0';

--- a/src/lhsmtool_tsm.c
+++ b/src/lhsmtool_tsm.c
@@ -299,7 +299,7 @@ static int ct_parseopts(int argc, char *argv[])
 		{.name = "owner",          .has_arg = required_argument, .flag = NULL,                  .val = 'o'},
 		{.name = "servername",     .has_arg = required_argument, .flag = NULL,                  .val = 's'},
 		{.name = "conf",	   .has_arg = required_argument, .flag = NULL,		        .val = 'c'},
-		{.name = "fsname",	   .has_arg = no_argument, .flag = NULL,		        .val = 'f'},
+		{.name = "fsname",	   .has_arg = optional_argument, .flag = NULL,		        .val = 'f'},
 		{.name = "verbose",        .has_arg = required_argument, .flag = NULL,                  .val = 'v'},
 		{.name = "dry-run",	   .has_arg = no_argument,	 .flag = &opt.o_dry_run,        .val =   1},
 		{.name = "restore-stripe", .has_arg = no_argument,	 .flag = &opt.o_restore_stripe, .val =   1},
@@ -397,7 +397,7 @@ static int ct_parseopts(int argc, char *argv[])
 
 	/* Filespace name is set to Lustre mount point. */
 	if (!opt.o_fsname[0])
-        strncpy(opt.o_fsname, opt.o_mnt, DSM_MAX_FSNAME_LENGTH);
+		strncpy(opt.o_fsname, opt.o_mnt, DSM_MAX_FSNAME_LENGTH);
 
 	const size_t len_fsname = strlen(opt.o_fsname);
 	if (len_fsname > 2 && opt.o_fsname[len_fsname - 1] == '/')


### PR DESCRIPTION
This was done to allow the copytool to archive to the same fs (TSM) from different lustre instances.